### PR TITLE
should only hide multiplayer model for the user

### DIFF
--- a/Scenes/Player/Player.gd
+++ b/Scenes/Player/Player.gd
@@ -23,6 +23,7 @@ signal health_changed(health_value)
 @onready var dontwannadie = $DeathAnim/Idontwannadie
 @onready var deathsound = $DeathAnim/deathsound
 @onready var model_anim_player = $Camera3D/MutiplayerModel/AnimationPlayer
+@onready var multiplayermodel = $Camera3D/MutiplayerModel
 #player shooting
 var bullet_spawn
 var pistol_bullet_scene = preload("res://Scenes/Player/pistol_bullet.tscn")
@@ -112,11 +113,12 @@ func _enter_tree():
 
 
 func _ready(): #balls
-	# Hide death UI/effects for everyone on spawn (host + clients)
+	# Hide death UI/effects/MPmodel for everyone on spawn (host + clients)
 	dontwannadie.hide()
 	deathanimplayer.stop()
 	deathsound.stop()
 	healthbar.show()
+	multiplayermodel.hide()
 
 	Global.player = self
 


### PR DESCRIPTION
This pull request makes a minor improvement to the player initialization logic by ensuring the multiplayer model is hidden on player spawn. This helps maintain a consistent state for all players when the scene loads.

- Player spawn initialization:
  * Added `multiplayermodel` as an `onready` variable to reference the multiplayer model node.
  * Updated the `_ready()` function to hide the multiplayer model on spawn, along with other death-related UI/effects.