### PR TITLE
Update Player.gd

### DIFF
--- a/Scenes/Player/Player.gd
+++ b/Scenes/Player/Player.gd
@@ -89,8 +89,11 @@ func die():
 	var player_id = multiplayer.get_unique_id()
 	rpc_id(1, "request_respawn", player_id)
 	
-	
 
+@rpc ("call_remote")
+func _balls():
+	multiplayermodel.hide()
+	
 @rpc("authority", "reliable")
 func spawn_bullet(is_rifle: bool, transform: Transform3D, shooter_peer: int):
 	var bullet_scene = rifle_bullet_scene if is_rifle else pistol_bullet_scene
@@ -112,14 +115,13 @@ func _enter_tree():
 	set_multiplayer_authority(str(name).to_int())
 
 
-func _ready(): #balls
+func _ready(): 
 	# Hide death UI/effects/MPmodel for everyone on spawn (host + clients)
 	dontwannadie.hide()
 	deathanimplayer.stop()
 	deathsound.stop()
 	healthbar.show()
-	multiplayermodel.hide()
-
+	_balls()
 	Global.player = self
 
 	# From here on, only do local-authority setup


### PR DESCRIPTION
This pull request refactors how the player model is hidden when the player spawns or dies. The logic for hiding the `multiplayermodel` has been moved into a new RPC method, and `_ready()` now calls this method instead of hiding the model directly.

**Player model hide logic refactor:**

* Added a new remote procedure call (RPC) method `_balls()` to hide the `multiplayermodel`, and replaced the direct call in `_ready()` with a call to this new method. (`Scenes/Player/Player.gd`) [[1]](diffhunk://#diff-dc64cb970b1ee602c61479d87cec0f218c5cb9817d47fc0267ba97b1373d726eR93-R95) [[2]](diffhunk://#diff-dc64cb970b1ee602c61479d87cec0f218c5cb9817d47fc0267ba97b1373d726eL115-R124)