### PR TITLE
done fixed

### DIFF
--- a/Scenes/Player/Player.gd
+++ b/Scenes/Player/Player.gd
@@ -24,6 +24,7 @@ signal health_changed(health_value)
 @onready var deathsound = $DeathAnim/deathsound
 @onready var model_anim_player = $Camera3D/MutiplayerModel/AnimationPlayer
 @onready var multiplayermodel = $Camera3D/MutiplayerModel
+@onready var playerarms = $Camera3D/man/Armature
 #player shooting
 var bullet_spawn
 var pistol_bullet_scene = preload("res://Scenes/Player/pistol_bullet.tscn")
@@ -89,10 +90,6 @@ func die():
 	var player_id = multiplayer.get_unique_id()
 	rpc_id(1, "request_respawn", player_id)
 	
-
-@rpc ("call_remote")
-func _balls():
-	multiplayermodel.hide()
 	
 @rpc("authority", "reliable")
 func spawn_bullet(is_rifle: bool, transform: Transform3D, shooter_peer: int):
@@ -121,8 +118,13 @@ func _ready():
 	deathanimplayer.stop()
 	deathsound.stop()
 	healthbar.show()
-	_balls()
 	Global.player = self
+	if is_multiplayer_authority():
+		multiplayermodel.hide()
+		playerarms.show()
+	else:
+		multiplayermodel.show()
+		playerarms.hide()
 
 	# From here on, only do local-authority setup
 	if not is_multiplayer_authority():


### PR DESCRIPTION
This pull request updates the player model visibility logic in the `Player.gd` script to better handle multiplayer authority, and removes an unused remote procedure. The main changes focus on ensuring the correct player model (either `multiplayermodel` or `playerarms`) is shown depending on whether the local player is the multiplayer authority.

**Multiplayer model visibility improvements:**

* Added initialization for `playerarms` node and updated `_ready()` to show or hide `multiplayermodel` and `playerarms` based on multiplayer authority, ensuring correct model visibility for local and remote players. [[1]](diffhunk://#diff-dc64cb970b1ee602c61479d87cec0f218c5cb9817d47fc0267ba97b1373d726eR27) [[2]](diffhunk://#diff-dc64cb970b1ee602c61479d87cec0f218c5cb9817d47fc0267ba97b1373d726eL124-R127)

**Code cleanup:**

* Removed the unused `_balls` remote procedure and its invocation, simplifying the code and removing redundant logic for hiding the multiplayer model. [[1]](diffhunk://#diff-dc64cb970b1ee602c61479d87cec0f218c5cb9817d47fc0267ba97b1373d726eL93-L96) [[2]](diffhunk://#diff-dc64cb970b1ee602c61479d87cec0f218c5cb9817d47fc0267ba97b1373d726eL124-R127)