### PR TITLE
Remove unused variables from paused_menu.gd

### DIFF
--- a/Scenes/pause menu/paused_menu.gd
+++ b/Scenes/pause menu/paused_menu.gd
@@ -5,10 +5,6 @@ extends Control
 #@onready var reticle = $"../CanvasLayer/HUD/Reticle"
 @onready var player = preload("res://Scenes/Player/Player.gd")
 
-
-@onready var pause_music: AudioStreamPlayer = $AudioStreamPlayer
-@onready var ip_label: Label = $IpLabel
-
 var _is_paused: bool = false:
 	set = set_paused
 


### PR DESCRIPTION
Deleted unused onready variables for pause_music and ip_label to clean up the script and improve maintainability.