### PR TITLE
Implement player respawn at random spawn point

### DIFF
--- a/Scenes/Player/Player.gd
+++ b/Scenes/Player/Player.gd
@@ -78,7 +78,9 @@ func take_damage(amount: int):
 		await get_tree().create_timer(4.59).timeout #respawn timer
 		healthbar.show()
 		health = max_health
-		position = Vector3.ZERO
+		var spawner = get_node("/root/SpaceshipMap/Spawner")
+		spawner.respawn_player(self)
+		#position = Vector3.ZERO
 		ammo = 12
 		ammo_rifle = 32
 		update_ammo_counter()

--- a/Scenes/spawner.gd
+++ b/Scenes/spawner.gd
@@ -15,6 +15,7 @@ var enemy_scenes := []
 var spawn_timer: Timer
 
 func _ready():
+	randomize()
 	spawn_timer = Timer.new()
 	spawn_timer.wait_time = spawn_interval
 	spawn_timer.timeout.connect(spawn_enemy)
@@ -29,6 +30,11 @@ func _ready():
 		Enemies = hud.get_node_or_null("Enemies")
 
 	#start_next_wave()
+
+
+func respawn_player(player):
+	var pos = get_random_spawn_point_position()
+	player.global_transform.origin = pos
 
 func start_next_wave():
 	current_wave += 1


### PR DESCRIPTION
Player now respawns at a random spawn point using the spawner's respawn_player method instead of resetting position to Vector3.ZERO. Added respawn_player function to spawner.gd and ensured randomization is initialized.